### PR TITLE
Removed method for setting execution time for a trial

### DIFF
--- a/src/main/java/com/simon/dom/Trial.java
+++ b/src/main/java/com/simon/dom/Trial.java
@@ -24,8 +24,4 @@ public class Trial<T> {
 		return executionTime;
 	}
 
-	public void setExecutionTime(double executionTime) {
-		this.executionTime = executionTime;
-	}
-
 }


### PR DESCRIPTION
Hi, I removed the method for setting the execution time as the client should not be able to influence this. I hope you agree. 

Cheers,
CR9